### PR TITLE
複数のoriginからcorsを許可できるよう改修

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# AWS SAM 検証用リポジトリ
+## チュートリアル: Hello World アプリケーションのデプロイよりSAMの環境構築を行なった
+https://docs.aws.amazon.com/ja_jp/serverless-application-model/latest/developerguide/serverless-getting-started-hello-world.html
+
 # sam-app
 
 This project contains source code and supporting files for a serverless application that you can deploy with the SAM CLI. It includes the following files and folders.

--- a/cors_headers/python/cors_headers.py
+++ b/cors_headers/python/cors_headers.py
@@ -1,0 +1,6 @@
+def get_cors_headers(origin):
+    return {
+        'Access-Control-Allow-Origin': origin,
+        'Access-Control-Allow-Headers': 'Content-Type',
+        'Access-Control-Allow-Methods': 'OPTIONS,POST,GET'
+    }

--- a/hello_world/app.py
+++ b/hello_world/app.py
@@ -1,13 +1,32 @@
 import json
+# from ./cors_headers/python/cors_headers.py import get_cors_headers
+def get_cors_headers(origin):
+    return {
+        'Access-Control-Allow-Origin': origin,
+        'Access-Control-Allow-Headers': 'Content-Type',
+        'Access-Control-Allow-Methods': 'OPTIONS,POST,GET'
+    }
 
 def lambda_handler(event, context):
-    return {
-        "statusCode": 200,
-        "body": json.dumps({
-            "item": "hello lambda!",
-            # "location": ip.text.replace("\n", "")
-        }),
-        "headers": {
-            'Access-Control-Allow-Origin': '*',
-        },
-    }
+    origin = event["headers"].get("origin")
+
+    allowed_origins = ['http://localhost:3000', 'https://d3uwz4aj2jk54u.cloudfront.net/index.html']
+
+    if origin in allowed_origins:
+        cors_headers = get_cors_headers(origin)
+
+        return {
+            "statusCode": 200,
+            "body": json.dumps({
+                "item": "hello lambda!",
+                # "location": ip.text.replace("\n", "")
+            }),
+            "headers": cors_headers
+        }
+    else:
+        return {
+            "statusCode": 403,
+            "body": json.dumps({
+                "message": "Origin not allowed.",
+            }),
+        }

--- a/template.yaml
+++ b/template.yaml
@@ -26,6 +26,19 @@ Resources:
           Properties:
             Path: /hello
             Method: get
+      Policies:
+        - AWSLambda_FullAccess
+      Layers:
+        - !Ref CorsHeadersLayer
+
+  CorsHeadersLayer:
+    Type: AWS::Serverless::LayerVersion
+    Properties:
+        LayerName: cors-headers
+        Description: CORS Headers Layer
+        ContentUri: cors_headers/
+        CompatibleRuntimes:
+          - python3.9
 
 Outputs:
   # ServerlessRestApi is an implicit API created out of Events key under Serverless::Function


### PR DESCRIPTION
# 複数のoriginからcorsを許可できるよう改修

## 概要
- APIGatewayの仕様上、`Access-Control-Allow-Origin`を複数設定することができないためlambdaよりリクエストしてきたオリジンを調べ 、あらがじめ決められたオリジンであればリクエストを許可する実装とした。

## 参考
- https://docs.aws.amazon.com/ja_jp/apigateway/latest/developerguide/how-to-cors.htmllocal
- https://www.tdi.co.jp/miso/aws-whitelist-api